### PR TITLE
Fix delete bug in SectionTraining

### DIFF
--- a/WeightLossApp/Model/Models/Training.cs
+++ b/WeightLossApp/Model/Models/Training.cs
@@ -11,7 +11,7 @@ namespace Model.Models
         }
 
         public int Id { get; set; }
-        public int SectionTrainingId { get; set; }
+        public int? SectionTrainingId { get; set; }
         public string Complexity { get; set; }
 
         public virtual SectionTraining SectionTraining { get; set; }

--- a/WeightLossApp/WeightLossApp/Controllers/SectionTrainingController.cs
+++ b/WeightLossApp/WeightLossApp/Controllers/SectionTrainingController.cs
@@ -54,6 +54,9 @@ namespace WeightLossApp.Controllers
         [HttpDelete("{id}")]
         public JsonResult Delete(int id)
         {
+            // Cascade delete in other tables or set null
+            CascadeDelete(id);
+
             SectionTraining item = _context.Find<SectionTraining>(id);
             _context.SectionTraining.Remove(item);
             _context.SaveChanges();
@@ -61,5 +64,22 @@ namespace WeightLossApp.Controllers
             return new JsonResult("Deleted successfully");
         }
         #endregion
+
+        private void CascadeDelete(int id)
+        {
+            CascadeDeleteTraining(id);
+        }
+        private void CascadeDeleteTraining(int id)
+        {
+            foreach (Training training in _context.Training)
+            {
+                if (training.SectionTrainingId == id)
+                {
+                    training.SectionTrainingId = null;
+                    training.SectionTraining = null;
+                }
+            }
+            _context.SaveChanges();
+        }
     }
 }


### PR DESCRIPTION
Before this fix, if you wanted to delete a section in the table 'SectionTraining' and these values ​​were already used in table 'Training', you could not delete and an error occurred. To fix this bug, the function has been added to set NULL cascading in table 'Training'.