### PR TITLE
Fixed cascade delete in table Exercise

### DIFF
--- a/WeightLossApp/WeightLossApp/Controllers/ExerciseController.cs
+++ b/WeightLossApp/WeightLossApp/Controllers/ExerciseController.cs
@@ -56,6 +56,8 @@ namespace WeightLossApp.Controllers
         [HttpDelete("{id}")]
         public JsonResult Delete(int id)
         {
+            CascadeDelete(id);
+
             Exercise item = _context.Find<Exercise>(id);
             _context.Exercise.Remove(item);
             _context.SaveChanges();
@@ -63,5 +65,25 @@ namespace WeightLossApp.Controllers
             return new JsonResult("Deleted successfully");
         }
         #endregion
+
+        private void CascadeDelete(int id)
+        {
+            CascadeDeleteTrainingExercise(id);
+        }
+        
+        private void CascadeDeleteTrainingExercise(int id)
+        {
+            // If in TrainingExercise table column Exercise_ID equals id, delete this row 
+            foreach (TrainingExercise trainingExercise in _context.TrainingExercise)
+            {
+                if(trainingExercise.ExerciseId == id)
+                {
+                    _context.TrainingExercise.Remove(trainingExercise);
+                }
+            }
+
+            // Save data to database
+            _context.SaveChanges();
+        }
     }
 }


### PR DESCRIPTION
Before this fix, if you wanted to delete an exercise in the table 'Exercise' and these values ​​were already used in table 'TrainingExercise', you could not delete and an error occurred. To fix this bug, the function has been added to delete cascading in table 'TrainingExercise'.